### PR TITLE
Improve proof section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,65 +117,67 @@
     </section>
 
     <!-- Proof -->
-    <section class="alt-bg">
-        <div class="container">
-            <h2>Доказательства работоспособности</h2>
-            <p style="font-size: 24px;">Это не прогнозы — это наши реальные показатели сегодня:</p>
-            <div class="proof-metrics">
-                <div class="proof-metric">
-                    <div class="proof-value">120k ฿</div>
-                    <div class="proof-label">Выручка/месяц</div>
-                </div>
-                <div class="proof-metric">
-                    <div class="proof-value">50k ฿</div>
-                    <div class="proof-label">Прибыль/месяц</div>
-                </div>
-                <div class="proof-metric">
-                    <div class="proof-value">2000 ฿</div>
-                    <div class="proof-label">Средний чек</div>
-                </div>
+<section class="alt-bg">
+    <div class="container">
+        <h2>Доказательства работоспособности</h2>
+        <p style="font-size: 24px; text-align: center; margin-bottom: 60px;">Это не прогнозы — это наши реальные показатели сегодня:</p>
+        
+        <div class="proof-metrics">
+            <div class="proof-metric">
+                <div class="proof-value">120k ฿</div>
+                <div class="proof-label">Выручка/месяц</div>
             </div>
-            
-            <h3 style="margin-top: 80px;">Почему клиенты выбирают нас</h3>
-            <p class="compact">
-                <span style="color: #d4b39f; font-weight: 400;">Мы уже проверили</span>, что русские девушки готовы платить 60+$ за наше качество.
-            </p>
-            <p>
-                Такой же премиум-подход сработает с китаянками и европейками —<br>
-                все ценят профессионализм и результат.
-            </p>
-            
-            <div class="about-me-box">
-                <h3>Про меня и мою команду</h3>
-                <p style="text-align: center; margin-bottom: 12px;">
-                    Я создала систему обучения по стандартам топовых московских салонов.
+            <div class="proof-metric">
+                <div class="proof-value">50k ฿</div>
+                <div class="proof-label">Прибыль/месяц</div>
+            </div>
+            <div class="proof-metric">
+                <div class="proof-value">2000 ฿</div>
+                <div class="proof-label">Средний чек</div>
+            </div>
+        </div>
+
+        <!-- Отдельная секция для клиентов -->
+        <div class="client-section">
+            <h3>Почему клиенты выбирают нас</h3>
+            <div class="client-proof">
+                <p class="highlight-text">
+                    <span class="accent-text">Мы уже проверили</span>, что русские девушки готовы платить 60+$ за наше качество.
                 </p>
-                <p style="text-align: center; margin-bottom: 12px;">
-                    <span style="color: #d4b39f; font-weight: 400;">У меня есть команда</span>, которую я лично обучила.
-                </p>
-                <p style="text-align: center; margin-bottom: 30px;">
-                    Они контролируют качество работы тайских мастеров,<br>
-                    гарантируя стабильный премиум-уровень услуг.
-                </p>
-                <div class="about-stats">
-                    <div class="about-stat">
-                        <div class="about-stat-value">6 лет</div>
-                        <div class="about-stat-label">Опыта в beauty-индустрии</div>
-                    </div>
-                    <div class="about-stat">
-                        <div class="about-stat-value">100+</div>
-                        <div class="about-stat-label">Обученных мастеров</div>
-                    </div>
-                </div>
-                <p style="text-align: center; margin-top: 30px; font-size: 18px; color: #7a6f63; margin-bottom: 12px;">
-                    Моя роль — стратегия и контроль качества.
-                </p>
-                <p style="text-align: center; font-size: 18px; color: #7a6f63; margin-bottom: 0;">
-                    Операционкой занимается проверенная команда.
+                <p class="description-text">
+                    Такой же премиум-подход сработает с китаянками и европейками —<br>
+                    все ценят профессионализм и результат.
                 </p>
             </div>
         </div>
-    </section>
+        
+        <div class="about-me-box">
+            <h3>Про меня и мою команду</h3>
+            <div class="about-content">
+                <p>Я создала систему обучения по стандартам топовых московских салонов.</p>
+                <p><span class="accent-text">У меня есть команда</span>, которую я лично обучила.</p>
+                <p>Они контролируют качество работы тайских мастеров,<br>
+                   гарантируя стабильный премиум-уровень услуг.</p>
+            </div>
+            
+            <div class="about-stats">
+                <div class="about-stat">
+                    <div class="about-stat-value">6 лет</div>
+                    <div class="about-stat-label">Опыта в beauty-индустрии</div>
+                </div>
+                <div class="about-stat">
+                    <div class="about-stat-value">100+</div>
+                    <div class="about-stat-label">Обученных мастеров</div>
+                </div>
+            </div>
+            
+            <div class="about-footer">
+                <p>Моя роль — стратегия и контроль качества.</p>
+                <p>Операционкой занимается проверенная команда.</p>
+            </div>
+        </div>
+    </div>
+</section>
 
     <!-- Growth Model -->
     <section class="light-bg">

--- a/styles/main.css
+++ b/styles/main.css
@@ -737,3 +737,71 @@ li:hover:before {
 .list-style {
     line-height: 1.8;
 }
+/* Секция клиентов */
+.client-section {
+    margin: 80px 0;
+    text-align: center;
+}
+
+.client-section h3 {
+    font-size: 36px;
+    margin-bottom: 40px;
+    color: #2d2926;
+}
+
+.client-proof {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.highlight-text {
+    font-size: 24px;
+    font-weight: 400;
+    margin-bottom: 30px;
+    color: #2d2926;
+}
+
+.description-text {
+    font-size: 20px;
+    color: #5a5047;
+    line-height: 1.6;
+}
+
+.accent-text {
+    color: #d4b39f;
+    font-weight: 500;
+}
+
+/* Улучшенный about-me-box */
+.about-me-box {
+    background: #ffffff;
+    border: 2px solid #f0e8e0;
+    padding: 60px;
+    border-radius: 20px;
+    margin-top: 60px;
+    text-align: center;
+    box-shadow: 0 10px 30px rgba(212, 179, 159, 0.1);
+}
+
+.about-content {
+    margin-bottom: 50px;
+}
+
+.about-content p {
+    font-size: 20px;
+    color: #5a5047;
+    margin-bottom: 20px;
+    line-height: 1.6;
+}
+
+.about-footer {
+    margin-top: 40px;
+    padding-top: 30px;
+    border-top: 1px solid #f0e8e0;
+}
+
+.about-footer p {
+    font-size: 18px;
+    color: #7a6f63;
+    margin-bottom: 12px;
+}


### PR DESCRIPTION
## Summary
- replace the Proof section markup with a cleaner layout
- add styling for client section and improved about-me box

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68765d96d868832684ebfd786ced6ffe